### PR TITLE
03_architecture/Coding an LLM architecture: Fix URL link to Radford et al.

### DIFF
--- a/03_architecture/03.ipynb
+++ b/03_architecture/03.ipynb
@@ -92,7 +92,7 @@
    "source": [
     "- In the previous notebook, we used small embedding dimensions for token inputs and outputs for ease of illustration, ensuring they neatly fit on the screen\n",
     "- In this notebook, we consider embedding and model sizes akin to a small GPT-2 model\n",
-    "- We'll specifically code the architecture of the smallest GPT-2 model (124 million parameters), as outlined in Radford et al.'s [Language Models are Unsupervised Multitask Learners](https://d4mucfpksywv.cloudfront.net/better-language-models/language_models_are_unsupervised_multitask_learners.pdf) (note that the initial report lists it as 117M parameters, but this was later corrected in the model weight repository)\n"
+    "- We'll specifically code the architecture of the smallest GPT-2 model (124 million parameters), as outlined in Radford et al.'s [Language Models are Unsupervised Multitask Learners](https://cdn.openai.com/better-language-models/language_models_are_unsupervised_multitask_learners.pdf) (note that the initial report lists it as 117M parameters, but this was later corrected in the model weight repository)\n"
    ]
   },
   {


### PR DESCRIPTION
This PR aims to fix or update the URL link to the work "Language Models are Unsupervised Multitask Learners" by Radford et al. in the Jupyter notebook for "Coding an LLM architecture" (folder 03_architecture).

Currently, the link is changed from https://d4mucfpksywv.cloudfront.net/better-language-models/language-models.pdf to https://cdn.openai.com/better-language-models/language_models_are_unsupervised_multitask_learners.pdf.

More generally, one could point to https://api.semanticscholar.org/CorpusID:160025533. Besides https://gwern.net/doc/ai/nn/transformer/gpt/2/2019-radford.pdf and https://www.techbooky.com/wp-content/uploads/2019/02/Better-Language-Models-and-Their-Implications.pdf, there also the link https://d4mucfpksywv.cloudfront.net/better-language-models/language-models.pdf is mentioned, which leads to this error:

```
This XML file does not appear to have any style information associated with it. The document tree is shown below.
<Error>
<Code>AccessDenied</Code>
<Message>Access Denied</Message>
<RequestId>48DSG95D713W8RXX</RequestId>
<HostId>8Kh4Je4XqmGxWDjjI2Yqw9S7mkmM9t6hhkcF7w0TVbBn83e3V6EjgmSLUvOQM+4Yz7k995Eig1c=</HostId>
</Error>
```

--------------
Thanks for providing these resources freely available!

